### PR TITLE
Remove unused dependency on vmm-sys-util crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfio-bindings"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["The Cloud Hypervisor Authors"]
 license = "Apache-2.0 OR BSD-3-Clause"
 description = "Rust FFI bindings to vfio generated using bindgen."
@@ -11,6 +11,3 @@ keywords = ["vfio"]
 
 [features]
 vfio-v5_0_0 = []
-
-[dependencies]
-vmm-sys-util = "0.1.1"


### PR DESCRIPTION
Currently the vfio-bindings locks down vmm-sys-util crate to 0.1.1
version, which causes multiple versions of vmm-sys-util crate as below:
vfio-ioctls v0.1.0 (/ws/src/vmm/rust-vmm/vfio-ioctls.git)
├── byteorder v1.2.7
├── kvm-bindings v0.2.0
│   └── vmm-sys-util v0.3.1
│       └── libc v0.2.66
├── kvm-ioctls v0.4.0
│   ├── kvm-bindings v0.2.0 (*)
│   ├── libc v0.2.66 (*)
│   └── vmm-sys-util v0.3.1 (*)
├── log v0.4.8
│   └── cfg-if v0.1.10
├── vfio-bindings v0.1.0
│   └── vmm-sys-util v0.1.1
│       └── libc v0.2.66 (*)
├── vm-memory v0.1.0 (https://github.com/rust-vmm/vm-memory#beaf2159)
│   ├── cast v0.2.3
│   │   [build-dependencies]
│   │   └── rustc_version v0.2.3
│   │       └── semver v0.9.0
│   │           └── semver-parser v0.7.0
│   └── libc v0.2.66 (*)
└── vmm-sys-util v0.3.1 (*)

Actually the vfio-bindings crate doesn't make use of the vmm-sys-util at
all, so remove the dependency.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>