### PR TITLE
vfio-bindings version v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-# v0.1.0
+# [v0.2.0]
+
+## Added
+
+- Add FAM wrappers for vfio\_irq\_set
+- Update vmm-sys-util version to ">=0.2.0"
+
+# [v0.1.0]
 
 This is the first `vfio-bindings` crate release.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfio-bindings"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["The Cloud Hypervisor Authors"]
 license = "Apache-2.0 OR BSD-3-Clause"
 description = "Rust FFI bindings to vfio generated using bindgen."


### PR DESCRIPTION
- Update crate version to 0.2.0
- Add FAM wrappers for vfio\_irq\_set
- Update vmm-sys-util version to ">=0.2.0"

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>