### PR TITLE
Release v0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [v0.3.0]
+
+## Added
+
+- Update vmm-sys-util version to ">=0.8.0"
+
 # [v0.2.0]
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfio-bindings"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["The Cloud Hypervisor Authors"]
 license = "Apache-2.0 OR BSD-3-Clause"
 description = "Rust FFI bindings to vfio generated using bindgen."
@@ -14,7 +14,7 @@ vfio-v5_0_0 = []
 fam-wrappers = ["vmm-sys-util"]
 
 [dependencies]
-vmm-sys-util = { version = ">=0.2.0", optional = true }
+vmm-sys-util = { version = ">=0.8.0", optional = true }
 
 [dev-dependencies]
 byteorder = ">=1.2.1"

--- a/src/fam_wrappers.rs
+++ b/src/fam_wrappers.rs
@@ -63,7 +63,7 @@ mod tests {
         let event_fds: Vec<u32> = vec![0, 1, 2, 3, 4, 5];
 
         // Build a FAM wrapper for this vfio_irq_set.
-        let mut irq_set_wrapper = IrqSet::new(event_fds.len() * mem::size_of::<u32>());
+        let mut irq_set_wrapper = IrqSet::new(event_fds.len() * mem::size_of::<u32>()).unwrap();
         let mut irq_set_fam = irq_set_wrapper.as_mut_fam_struct();
 
         let fds_fam = irq_set_fam.as_mut_slice();


### PR DESCRIPTION
There's an interface change in vmm-sys-utils v0.8, so upgrade
vmm-sys-utils v0.8 and release vfio-bindings v0.3.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>