### PR TITLE
Update dependabot to open PRs monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,5 @@ updates:
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   open-pull-requests-limit: 10


### PR DESCRIPTION
This crate has very few PRs, so there is no reason to keep updating dependabot.